### PR TITLE
Avoid ASG race condition

### DIFF
--- a/union.py
+++ b/union.py
@@ -33,6 +33,7 @@ def lambda_handler(event, context):
     table = dynamodb_resource.Table('DDNS')
 
     if state == 'running':
+        time.sleep(60)
         instance = compute.describe_instances(InstanceIds=[instance_id])
         # Remove response metadata from the response
         instance.pop('ResponseMetadata')


### PR DESCRIPTION
EC2 instances created from an ASG do not get tags applied immediately. This sleep avoids a race condition.